### PR TITLE
set pydivert to version 1.0.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ except ImportError:
     from distutils.core import setup
 
 requirements = [
-    "pydivert",
+    "pydivert==1.0.2",
     "dpkt",
     "dnslib",
 ]


### PR DESCRIPTION
pydivert appears to have made changes in 2.0.0 that broke fakenet-ng
