### PR TITLE
Adding pcap files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+# pcap files (FakeNet-NG may generate these)
+*.pcap
+
 # C extensions
 *.so
 


### PR DESCRIPTION
Since FakeNet generates `*.pcap` files when `DumpPackets` is enabled in its configuration, these clutter the `Untracked files` portion of the output from `git status`. These are generally not files we want to check in, so it would be nice to tell Git to ignore them. I omitted `*.pcapng` because we currently don't generate new-format pcap files, but feel free to edit my PR if you want to add those.