### PR TITLE
Ftproot check

### DIFF
--- a/fakenet/listeners/FTPListener.py
+++ b/fakenet/listeners/FTPListener.py
@@ -108,6 +108,7 @@ class FTPListener():
 
             if not os.path.exists(self.ftproot_path):
                 self.logger.error('Could not locate ftproot directory: %s', self.ftproot_path)
+                sys.exit(1)
 
     def expand_ports(self, ports_list):
         ports = []

--- a/fakenet/listeners/FTPListener.py
+++ b/fakenet/listeners/FTPListener.py
@@ -107,7 +107,7 @@ class FTPListener():
             self.ftproot_path = os.path.join(os.path.dirname(__file__)), self.ftproot_path)
 
             if not os.path.exists(self.ftproot_path):
-                self.logger.error('Could not locate ftproot directory: %s' % (self.ftproot_path))
+                self.logger.error('Could not locate ftproot directory: %s', self.ftproot_path)
 
     def expand_ports(self, ports_list):
         ports = []

--- a/fakenet/listeners/FTPListener.py
+++ b/fakenet/listeners/FTPListener.py
@@ -100,6 +100,15 @@ class FTPListener():
         # Initialize webroot directory
         self.ftproot_path = self.config.get('ftproot','defaultFiles')
 
+        # Try absolute path first
+        if not os.path.exists(self.ftproot_path):
+
+            # Try to locate the ftproot directory relative to application path
+            self.ftproot_path = os.path.join(os.path.dirname(__file__)), self.ftproot_path)
+
+            if not os.path.exists(self.ftproot_path):
+                self.logger.error('Could not locate ftproot directory: %s' % (self.ftproot_path))
+
     def expand_ports(self, ports_list):
         ports = []
         for i in ports_list.split(','):

--- a/fakenet/listeners/FTPListener.py
+++ b/fakenet/listeners/FTPListener.py
@@ -104,7 +104,7 @@ class FTPListener():
         if not os.path.exists(self.ftproot_path):
 
             # Try to locate the ftproot directory relative to application path
-            self.ftproot_path = os.path.join(os.path.dirname(__file__)), self.ftproot_path)
+            self.ftproot_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), self.ftproot_path)
 
             if not os.path.exists(self.ftproot_path):
                 self.logger.error('Could not locate ftproot directory: %s', self.ftproot_path)


### PR DESCRIPTION
By testing FakeNet-NG as configured on REMnux, I discovered that `FTPListener.py` omits a helpful check that `HTTPListener.py` does to ensure that the `defaultFiles` path can be found relative to the script file itself if an absolute path is not provided. I've copied this check from the HTTP listener and tested on Remnux. @iphelix do you want to look this over and let me know if you see any problems before merging?