### PR TITLE
Issue34 nfnetlink error

### DIFF
--- a/fakenet/diverters/linutil.py
+++ b/fakenet/diverters/linutil.py
@@ -348,7 +348,7 @@ class LinUtilMixin():
                                     str(queue_nr) + ' per ') + procfs_path)
                         qnos.append(queue_nr)
         except IOError as e:
-            self.logger.warning(('Failed to open %s to enumerate netfilter ' +
+            self.logger.debug(('Failed to open %s to enumerate netfilter ' +
                                  'netlink queues, caller may proceed as if ' +
                                  'none are in use: %s') %
                                 (procfs_path, e.message))


### PR DESCRIPTION
Closes #34 . Changed the logger level to debug - Regular users are not interested in diagnostic information about nfqueue but can be useful for debugging.