### PR TITLE
Issue33 dns error

### DIFF
--- a/fakenet/diverters/linux.py
+++ b/fakenet/diverters/linux.py
@@ -413,11 +413,11 @@ class Diverter(DiverterBase, LinUtilMixin):
         if self.single_host_mode and self.is_set('modifylocaldns'):
             self.linux_modifylocaldns_ephemeral()
 
-        if self.is_configured('linuxflushdnscommand'):
+        if self.is_configured('linuxflushdnscommand') and self.single_host_mode:
             cmd = self.getconfigval('linuxflushdnscommand')
             ret = subprocess.call(cmd.split())
             if ret != 0:
-                self.logger.error('Failed to flush DNS cache.')
+                    self.logger.error('Failed to flush DNS cache.')
 
         if self.is_configured('linuxredirectnonlocal'):
             self.pdebug(DMISC, 'Processing LinuxRedirectNonlocal')

--- a/fakenet/diverters/linux.py
+++ b/fakenet/diverters/linux.py
@@ -417,7 +417,8 @@ class Diverter(DiverterBase, LinUtilMixin):
             cmd = self.getconfigval('linuxflushdnscommand')
             ret = subprocess.call(cmd.split())
             if ret != 0:
-                    self.logger.error('Failed to flush DNS cache.')
+                self.logger.error(
+                'Failed to flush DNS cache. Local machine may use cached DNS results.')
 
         if self.is_configured('linuxredirectnonlocal'):
             self.pdebug(DMISC, 'Processing LinuxRedirectNonlocal')

--- a/fakenet/diverters/winutil.py
+++ b/fakenet/diverters/winutil.py
@@ -975,7 +975,8 @@ class WinUtilMixin():
         try:
             subprocess.check_call('ipconfig /flushdns', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         except subprocess.CalledProcessError, e:
-            self.logger.error("Failed to flush DNS cache.")
+            self.logger.error(
+            "Failed to flush DNS cache. Local machine may use cached DNS results.")
         else:
             self.logger.info('Flushed DNS cache.')
 


### PR DESCRIPTION
closes #33 . Edited error messages to explain DNS cache failure. In linux, only flush DNS cache in singlehost mode since multihost does not use local cache.