### PR TITLE
Set ThreadedTCPServer connection threads to be in daemon mode

### DIFF
--- a/fakenet/listeners/ProxyListener.py
+++ b/fakenet/listeners/ProxyListener.py
@@ -189,10 +189,10 @@ class ThreadedUDPClientSocket(threading.Thread):
             self.logger.debug('Listener socket exception %s' % e)
 
 class ThreadedTCPServer(SocketServer.ThreadingMixIn, SocketServer.TCPServer):
-    pass
+    daemon_threads = True
 
 class ThreadedUDPServer(SocketServer.ThreadingMixIn, SocketServer.UDPServer):
-    pass
+    daemon_threads = True
 
 def get_top_listener(config, data, listeners, diverter, orig_src_ip, 
         orig_src_port, proto):
@@ -285,7 +285,7 @@ class ThreadedTCPRequestHandler(SocketServer.BaseRequestHandler):
                 listener_sock = ThreadedTCPClientSocket('localhost', 
                         top_listener.port, listener_q, remote_q, 
                         self.server.config, self.server.logger)
-                listener_sock.setDaemon(True)
+                listener_sock.daemon = True
                 listener_sock.start()
                 remote_sock.setblocking(0)
 
@@ -358,7 +358,7 @@ class ThreadedUDPRequestHandler(SocketServer.BaseRequestHandler):
                         listener_q, remote_q, self.server.config, 
                         self.server.logger, top_listener.port, 
                         self.server.fwd_table, orig_src_ip, orig_src_port)
-                listener_sock.setDaemon(True)
+                listener_sock.daemon = True
                 listener_sock.start()
                 remote_sock.setblocking(0)
 


### PR DESCRIPTION
This will allow fakenet to shut down when a request thread is still in play. I believe it is possible we might leak a client fd but the server _socket is being shut down_. 

To test:

1. Launch fakenet with default config in a screen session
1. In another screen session run `nc 127.0.0.1 8765` followed by sending `GET / HTTP/1.0 <enter> <enter>`
1. Ctrl+C fakenet and watch it shutdown. Check `nc` screen and see that it had exited