### PR TITLE
Issue 3 syslog

### DIFF
--- a/fakenet/fakenet.py
+++ b/fakenet/fakenet.py
@@ -6,6 +6,7 @@
 # Developed by Peter Kacherginsky
 
 import logging
+import logging.handlers
 
 import os
 import sys
@@ -288,15 +289,34 @@ def main():
                       action="store_true", dest="verbose", default=False,
                       help="print more verbose messages.")
     parser.add_option("-l", "--log-file", action="store", dest="log_file")
+    parser.add_option("-s", "--log-syslog", action="store_true", dest="syslog", default=False)
 
     (options, args) = parser.parse_args()
 
     logging_level = logging.DEBUG if options.verbose else logging.INFO
 
+    date_format = '%m/%d/%y %I:%M:%S %p'
+    logging.basicConfig(format='%(asctime)s [%(name)18s] %(message)s', datefmt=date_format, level=logging_level)
+    logger = logging.getLogger('') # Get the root logger i.e. ''
+
     if options.log_file:
-        logging.basicConfig(format='%(asctime)s [%(name)18s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.INFO, filename=options.log_file)
-    else:
-        logging.basicConfig(format='%(asctime)s [%(name)18s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p', level=logging.INFO)
+        logfile = None
+        try:
+            logfile = open(options.log_file, 'a')
+        except IOError:
+            print('Failed to open specified log file: %s' % (options.log_file))
+            return False
+            
+        loghandler = logging.StreamHandler(stream=open(options.log_file, 'a'))
+        loghandler.formatter = logging.Formatter('%(asctime)s [%(name)18s] %(message)s', datefmt=date_format)
+        logger.addHandler(loghandler)
+
+    if options.syslog:
+        sysloghandler = logging.handlers.SysLogHandler('/dev/log')
+        # Bothered to specify datefmt for consistency, but syslog generally
+        # logs the time on each log line, so %(asctime) is omitted here.
+        sysloghandler.formatter = logging.Formatter('FakeNet-NG: {"loggerName":"%(name)s", "moduleName":"%(module)s", "levelName":"%(levelname)s", "message":"%(message)s"}', datefmt=date_format)
+        logger.addHandler(sysloghandler)
 
     fakenet = Fakenet(logging_level)
     fakenet.parse_config(options.config_file)

--- a/fakenet/fakenet.py
+++ b/fakenet/fakenet.py
@@ -162,7 +162,7 @@ class Fakenet():
                 self.diverter = Diverter(self.diverter_config, self.listeners_config, ip_addrs, self.logging_level)
 
             else:
-                self.logger.error('Error: Your system %s is currently not supported.', platform_name)
+                self.logger.error('Error: Your system %s is currently not supported.' % (platform_name))
                 sys.exit(1)
 
         # Start all of the listeners
@@ -305,14 +305,23 @@ def main():
             logfile = open(options.log_file, 'a')
         except IOError:
             print('Failed to open specified log file: %s' % (options.log_file))
-            return False
+            sys.exit(1)
             
         loghandler = logging.StreamHandler(stream=open(options.log_file, 'a'))
         loghandler.formatter = logging.Formatter('%(asctime)s [%(name)18s] %(message)s', datefmt=date_format)
         logger.addHandler(loghandler)
 
     if options.syslog:
-        sysloghandler = logging.handlers.SysLogHandler('/dev/log')
+        platform_name = platform.system()
+        sysloghandler = None
+        if platform_name == 'Windows':
+            sysloghandler = logging.handlers.NTEventLogHandler('FakeNet-NG')
+        elif platform_name.lower().startswith('linux'):
+            sysloghandler = logging.handlers.SysLogHandler('/dev/log')
+        else:
+            print('Error: Your system %s is currently not supported.' % (platform_name))
+            sys.exit(1)
+
         # Bothered to specify datefmt for consistency, but syslog generally
         # logs the time on each log line, so %(asctime) is omitted here.
         sysloghandler.formatter = logging.Formatter('FakeNet-NG: {"loggerName":"%(name)s", "moduleName":"%(module)s", "levelName":"%(levelname)s", "message":"%(message)s"}', datefmt=date_format)


### PR DESCRIPTION
Closes #3. I found it onerous to test the Windows `NTEventLogHandler` because it requires Python Win32 extensions for NT which, after chasing these down via python.net => sourceforge => github, I find have requirements unto themselves. I am erring in favor of productivity/progress/feature parity by leaving the code in place. I have tested that it does not interfere with or alter Windows functionality.