### PR TITLE
HTTPListener can manage HTTP raw files

### DIFF
--- a/fakenet/defaultFiles/generate_204.RAW
+++ b/fakenet/defaultFiles/generate_204.RAW
@@ -1,0 +1,4 @@
+HTTP/1.0 204 No Content
+Content-Length: 0
+Date: <RAW-DATE>
+

--- a/fakenet/defaultFiles/success.txt.RAW
+++ b/fakenet/defaultFiles/success.txt.RAW
@@ -1,0 +1,13 @@
+HTTP/1.1 200 OK
+Content-Type: text/plain
+Content-Length: 8
+Last-Modified: Mon, 15 May 2017 18:04:40 GMT
+ETag: "ae780585f49b94ce1444eb7d28906123"
+Accept-Ranges: bytes
+Server: AmazonS3
+X-Amz-Cf-Id: DOMFBGDxBc9xK7seJjwbgRcfGUMjatIzbXRAY4nKJan2KJgKx6nM9g==
+Cache-Control: no-cache, no-store, must-revalidate
+Date: <RAW-DATE>
+Connection: close
+
+success


### PR DESCRIPTION
when processing GET/POST the process looks also for a .RAW file

-  if it does not exists, it works as usual
-  if exists, it sends back it
-  For example, with the following, named "success.txt.RAW"


```
HTTP/1.1 200 OK
Content-Type: text/plain
Content-Length: 8
Last-Modified: Mon, 15 May 2017 18:04:40 GMT
ETag: "ae780585f49b94ce1444eb7d28906123"
Accept-Ranges: bytes
Server: AmazonS3
X-Amz-Cf-Id: DOMFBGDxBc9xK7seJjwbgRcfGUMjatIzbXRAY4nKJan2KJgKx6nM9g==
Cache-Control: no-cache, no-store, must-revalidate
Date: <RAW-DATE>
Connection: close

success
```



I can emulate the Firefox connection portal.
As you can see I also implemented some "variables" replaced at runtime. In this case ("\<RAW-DATE\>") is the current time. May be I can add more.