### PR TITLE
Extensive Logging enhancements

### DIFF
--- a/fakenet/configs/default.ini
+++ b/fakenet/configs/default.ini
@@ -113,22 +113,43 @@ BlackListPortsUDP: 67, 68, 137, 138, 443, 1900, 5355
 # HostBlackList: 6.6.6.6
 
 ###############################################################################
+#[RemoteLogger]
+#Enabled : Yes
+# logger_type: [syslog,splunk]
+#Logger_Type : syslog
+# logger_host: [ip,name,fqdn]
+#Logger_Host : localhost
+#Logger_Port : 514
+# logger_proto: [udp,tcp]
+#Logger_Protocol : TCP
 # Splunk remote logging configuration
 # http://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector
-[Splunk]
-LogToSplunk : No
-SplunkHost : splunk_hostname
-Port: 8080
-Cert_verify : True
-HECToken : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-Source : fakenet:daemon
-Sourcetype : json
+#Splunk_Cert_verify : True
+#Splunk_HECToken : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+#Splunk_Source : fakenet:daemon
+#Splunk_Sourcetype : _json
+[RemoteLogger]
+EnableRemoteLogger : False
+Logger_Type: splunk
+Logger_Host : localhost
+Logger_Port: 8080
+Splunk_Cert_verify : True
+Splunk_HECToken : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+Splunk_Source : fakenet:daemon
+
+#[RemoteLogger]
+#Enabled : Yes
+#Logger_Type : syslog
+#Logger_Host : localhost
+#Logger_Port : 514
+#Logger_Protocol : TCP
+
 
 ###############################################################################
 # Listener Configuration
 #
 # Listener configuration consists of generic settings used by the diverter which
-# are the same for all listeners and listener specific settings. 
+# are the same for all listeners and listener specific settings.
 #
 # NOTE: Listener section names will be used for logging.
 #

--- a/fakenet/configs/default.ini
+++ b/fakenet/configs/default.ini
@@ -5,7 +5,7 @@
 
 # Specify whether or not FakeNet should divert traffic. Disable if you want to
 # just start listeners and direct traffic manually (e.g. modify DNS server)
-DivertTraffic:         Yes
+DivertTraffic:         No
 
 ###############################################################################
 # Diverter Configuration
@@ -29,7 +29,7 @@ NetworkMode:           Auto
 # DebugLevel (Linux only as of this writing): specify fine-grained debug print
 # flags to enable. Enabling all logging when verbose mode is selected results
 # in an unacceptable overhead cost, hence this setting.
-DebugLevel:            Off
+DebugLevel:            On
 
 # MultiHost mode only: Specify what interfaces the Linux Diverter should create
 # an iptables rule for to redirect traffic destined for other hosts to the
@@ -111,6 +111,18 @@ BlackListPortsUDP: 67, 68, 137, 138, 443, 1900, 5355
 
 # Specify hosts to ignore when diverting traffic.
 # HostBlackList: 6.6.6.6
+
+###############################################################################
+# Splunk remote logging configuration
+# http://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector
+[Splunk]
+LogToSplunk : No
+SplunkHost : splunk_hostname
+Port: 8080
+Cert_verify : True
+HECToken : xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+Source : fakenet:daemon
+Sourcetype : json
 
 ###############################################################################
 # Listener Configuration
@@ -239,7 +251,7 @@ HostBlackList: 5.5.5.5
 Hidden:      False
 
 [DNS Server]
-Enabled:     True
+Enabled:     False
 Port:        53
 Protocol:    UDP
 Listener:    DNSListener
@@ -251,7 +263,7 @@ Hidden:      False
 
 [HTTPListener80]
 Enabled:     True
-Port:        80
+Port:        8080
 Protocol:    TCP
 Listener:    HTTPListener
 UseSSL:      No
@@ -264,7 +276,7 @@ Hidden:      False
 
 [HTTPListener443]
 Enabled:     True
-Port:        443
+Port:        8443
 Protocol:    TCP
 Listener:    HTTPListener
 UseSSL:      Yes
@@ -274,7 +286,7 @@ DumpHTTPPostsFilePrefix: http
 Hidden:      False
 
 [SMTPListener]
-Enabled:     True
+Enabled:     False
 Port:        25
 Protocol:    TCP
 Listener:    SMTPListener
@@ -283,7 +295,7 @@ Hidden:      False
 
 [FTPListener21]
 Enabled:     True
-Port:        21
+Port:        2121
 Protocol:    TCP
 Listener:    FTPListener
 UseSSL:      No
@@ -300,7 +312,7 @@ Protocol:    TCP
 Hidden:      False
 
 [IRCServer]
-Enabled:     True
+Enabled:     False
 Port:        6667
 Protocol:    TCP
 Listener:    IRCListener
@@ -311,7 +323,7 @@ Timeout:     30
 Hidden:      False
 
 [TFTPListener]
-Enabled:     True
+Enabled:     False
 Port:        69
 Protocol:    UDP
 Listener:    TFTPListener
@@ -320,7 +332,7 @@ Hidden:      False
 TFTPFilePrefix:  tftp
 
 [POPServer]
-Enabled:     True
+Enabled:     False
 Port:        110
 Protocol:    TCP
 Listener:    POPListener

--- a/fakenet/diverters/diverterbase.py
+++ b/fakenet/diverters/diverterbase.py
@@ -16,7 +16,7 @@ class DiverterBase(fnconfig.Config):
 
 
     def init_base(self, diverter_config, listeners_config, ip_addrs,
-                  logging_level=logging.INFO):
+                  logger=None, logging_level=logging.DEBUG):
         # For fine-grained control of subclass debug output. Does not control
         # debug output from DiverterBase. To see DiverterBase debug output,
         # pass logging.DEBUG as the logging_level argument to init_base.
@@ -31,7 +31,10 @@ class DiverterBase(fnconfig.Config):
         self.pcap_filename = ''
         self.pcap_lock = None
 
-        self.logger = logging.getLogger('Diverter')
+        if logger is not None:
+            self.logger = logger
+        else:
+            self.logger = logging.getLogger('Diverter')
         self.logger.setLevel(logging_level)
 
         portlists = ['BlackListPortsTCP', 'BlackListPortsUDP']
@@ -410,12 +413,12 @@ class DiverterBase(fnconfig.Config):
             else:
                 self.default_listener['TCP'] = int(
                     self.listeners_config[self.getconfigval('defaulttcplistener').lower()]['port'])
-                self.logger.error('Using default listener %s on port %d', self.getconfigval(
+                self.logger.error('Using default listener %s on port %d.', self.getconfigval(
                     'defaulttcplistener').lower(), self.default_listener['TCP'])
 
                 self.default_listener['UDP'] = int(
                     self.listeners_config[self.getconfigval('defaultudplistener').lower()]['port'])
-                self.logger.error('Using default listener %s on port %d', self.getconfigval(
+                self.logger.error('Using default listener %s on port %d.', self.getconfigval(
                     'defaultudplistener').lower(), self.default_listener['UDP'])
 
             # Re-marshall these into a readily usable form...

--- a/fakenet/diverters/linux.py
+++ b/fakenet/diverters/linux.py
@@ -200,9 +200,9 @@ class Diverter(DiverterBase, LinUtilMixin):
 
 
     def __init__(self, diverter_config, listeners_config, ip_addrs,
-                 logging_level=logging.INFO):
+                 logger=None, logging_level=logging.INFO):
         self.init_base(diverter_config, listeners_config, ip_addrs,
-                       logging_level)
+                       logger, logging_level)
 
         self.init_linux_mixin()
         self.init_diverter_linux()

--- a/fakenet/listeners/BITSListener.py
+++ b/fakenet/listeners/BITSListener.py
@@ -1,6 +1,7 @@
 # Based on a simple BITS server by Dor Azouri <dor.azouri@safebreach.com>
 
 import logging
+import ListenerBase
 
 import os
 import sys
@@ -484,11 +485,9 @@ class BITSListener():
         return confidence
         
     def __init__(self, config={}, name='BITSListener', 
-            logger=None, logging_level=logging.DEBUG, running_listeners=None):
+            logging_level=logging.DEBUG, running_listeners=None):
 
-        self.logger = logger or logging.getLogger(name)
-        self.logger.setLevel(logging_level)
-  
+        self.logger = ListenerBase.set_logger("%s:%s" % (self.__module__, name), config, logging_level)
         self.config = config
         self.name = name
         self.local_ip  = '0.0.0.0'
@@ -497,6 +496,9 @@ class BITSListener():
         self.NAME = 'BITS'
         self.PORT = self.config.get('port')
 
+        ssl_str = 'HTTPS' if self.config.get('usessl') == 'Yes' else 'HTTP'
+        self.logger.info('Starting %s server on %s:%s' % (ssl_str, self.local_ip, self.config.get('port')))
+
         self.logger.debug('Initialized with config:')
         for key, value in config.iteritems():
             self.logger.debug('  %10s: %s', key, value)
@@ -504,9 +506,6 @@ class BITSListener():
         self.bits_file_prefix = self.config.get('bitsfileprefix', 'bits')
 
     def start(self):
-        http_str = 'HTTPS' if self.config.get('usessl') == 'Yes' else 'HTTP'
-        self.logger.info('Starting %s server on %s:%s' % (http_str, self.local_ip, self.config.get('port')))
-
         self.server = ThreadedHTTPServer((self.local_ip, int(self.config.get('port'))), SimpleBITSRequestHandler)
         self.server.logger = self.logger
         self.server.bits_file_prefix = self.bits_file_prefix

--- a/fakenet/listeners/HTTPListener.py
+++ b/fakenet/listeners/HTTPListener.py
@@ -1,4 +1,5 @@
 import logging
+import json
 
 import os
 import sys
@@ -56,12 +57,15 @@ class HTTPListener():
             self, 
             config={}, 
             name='HTTPListener', 
-            logging_level=logging.DEBUG, 
+            logger=None,
+            logging_level=logging.DEBUG
             ):
 
-        self.logger = logging.getLogger(name)
+        self.logger = logger or logging.getLogger(name)
+
+        #self.logger.name = name
         self.logger.setLevel(logging_level)
-  
+
         self.config = config
         self.name = name
         self.local_ip  = '0.0.0.0'
@@ -82,8 +86,9 @@ class HTTPListener():
 
 
     def start(self):
-        self.logger.debug('Starting...')
-            
+        http_str = 'HTTPS' if self.config.get('usessl') == 'Yes' else 'HTTP'
+        self.logger.info('Starting %s server on %s:%s' % (http_str, self.local_ip, self.config.get('port')))
+
         self.server = ThreadedHTTPServer((self.local_ip, int(self.config.get('port'))), ThreadedHTTPRequestHandler)
         self.server.logger = self.logger
         self.server.config = self.config
@@ -112,7 +117,8 @@ class HTTPListener():
         self.server_thread.start()
 
     def stop(self):
-        self.logger.info('Stopping...')
+        http_str = 'HTTPS' if self.config.get('usessl') == 'Yes' else 'HTTP'
+        self.logger.info('Stopping %s server on %s:%s' % (http_str, self.local_ip, self.config.get('port')))
         if self.server:
             self.server.shutdown()
             self.server.server_close()
@@ -176,17 +182,17 @@ class ThreadedHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
     def do_POST(self):
         self.server.logger.info('Received a POST request')
 
-        post_body = ''
+        self.post_body = ''
 
         content_len = int(self.headers.get('content-length', 0))
-        post_body = self.rfile.read(content_len)
+        self.post_body = self.rfile.read(content_len)
 
         # Process request
         self.server.logger.info('%s', '-'*80)
         self.server.logger.info(self.requestline)
         for line in str(self.headers).split("\n"):
             self.server.logger.info(line)
-        for line in post_body.split("\n"):
+        for line in self.post_body.split("\n"):
             self.server.logger.info(line)
         self.server.logger.info('%s', '-'*80)
 
@@ -200,7 +206,7 @@ class ThreadedHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
                 if http_f:
                     http_f.write(self.requestline + "\r\n")
                     http_f.write(str(self.headers) + "\r\n")
-                    http_f.write(post_body)
+                    http_f.write(self.post_body)
 
                     http_f.close()
                 else:
@@ -259,6 +265,38 @@ class ThreadedHTTPRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         return (response, response_type)
 
     def log_message(self, format, *args):
+        '''Construct CIM compliant log message as a dict object which would be indexed in splunk as json'''
+
+        # http://docs.splunk.com/Documentation/CIM/4.9.1/User/Web
+        if 'user-agent' in self.headers.dict.keys():
+            self.headers.dict['http_user_agent'] = self.headers.dict.pop('user-agent')
+            self.headers.dict['http_user_agent_length'] = len(self.headers.dict['http_user_agent'])
+
+        if 'referrer' in self.headers.dict.keys():
+            self.headers.dict['http_referrer'] = self.headers.dict.pop('referrer')
+
+        if 'host' in self.headers.dict.keys():
+            self.headers.dict['site'] = self.headers.dict.pop('host')
+
+        try:
+            # Advertised fake web server signature
+            self.headers.dict['vendor'] = self.server.config.version
+        except:
+            pass
+
+        try:
+            self.headers.dict['protocol'] = self.server.config.protocol.lower()
+        except:
+            self.headers.dict['protocol'] = 'tcp'
+
+        logmsg = dict({'src': self.client_address[0], 'src_port':self.client_address[1], 'dest_port': self.server.server_port,
+                    'ssl':self.server.config['usessl'], 'http_method': self.command, 'http_header': self.headers.dict,
+                    'uri_query': self.path, 'http_protocol_version': self.protocol_version, 'listener': __name__})
+        if self.command == 'POST':
+            logmsg['post_body'] = self.post_body
+
+        #self.server.logger.info(json.dumps(logmsg, indent=2, sort_keys=True))
+        self.server.logger.info(logmsg)
         return
 
 

--- a/fakenet/listeners/ListenerBase.py
+++ b/fakenet/listeners/ListenerBase.py
@@ -1,5 +1,8 @@
 import logging
+import logging.handlers
+from socket import SOCK_DGRAM, SOCK_STREAM
 import os
+
 
 def safe_join(root, path):
     """ 
@@ -13,6 +16,7 @@ def safe_join(root, path):
     normpath = os.path.normpath(path)
 
     return root + normpath
+
 
 def abs_config_path(path):
     """
@@ -37,3 +41,111 @@ def abs_config_path(path):
         return os.path.abspath(relpath)
 
     return None
+
+
+def add_remote_logger(host, logger=logging.getLogger('FakeNet Listener'), port=514, proto='TCP'):
+    """
+    Attach a remote syslog handler to existing logger
+
+    :param host: IP, hostname or remote logger.  Can also be 'localhost'
+    :param logger: logging instance
+    :param port: Network port to send logs to
+    :param proto: Network protocol supported by remote logger
+    :return: Modified logger with remote handler attached
+    """
+    socket_type = {'UDP': SOCK_DGRAM, 'TCP': SOCK_STREAM }
+    return logger.addHandler(
+        logging.handlers.SysLogHandler(
+            (host, port),
+            logging.handlers.SysLogHandler.LOG_DAEMON,
+            socket_type[proto.upper()]
+        )
+    )
+
+
+def add_splunk_logger(host, hectoken, logger=logging.getLogger('FakeNet Listener'), port=8080, verify=True, source='FakeNet', sourcetype='_json'):
+    """
+    Attach a remote Splunk HTTP Event Collector handler to existing logger
+    http://docs.splunk.com/Documentation/SplunkCloud/latest/Data/UsetheHTTPEventCollector
+
+    :param host: IP, hostname of splunk search head, forwarder or indexer
+    :param hectoken: HTTP Event Collector token for authentication.
+    :param logger: logging instance
+    :param port: HEC port
+    :param verify: SSL verification
+    :param source: Splunk event source
+    :param sourcetype: Splunk event sourcetype.
+    :return: Modified logger with remote handler attached
+    """
+    class JSONFilter(logging.Filter):
+        """
+        Logging filter to filter out any non-json formatted events.
+        """
+        def filter(self, record):
+            return record.getMessage().startswith('{') and record.getMessage().endswith('}')
+
+    try:
+        from splunk_http_handler import SplunkHttpHandler
+        try:
+            splunk_handler = SplunkHttpHandler(
+                                host,
+                                hectoken,
+                                port=port,
+                                source=source,
+                                sourcetype=sourcetype,
+                                ssl_verify=bool(verify)
+                                )
+            splunk_handler.addFilter(JSONFilter())
+            logger.addHandler(splunk_handler)
+        except Exception as e:
+            logger.error("Failed to set Splunk log handler.  Exception: %s" % e)
+    except Exception as e:
+        logger.error("Failed to import Splunk python module (splunk_http_handler), Try 'pip install splunk_http_handler'")
+        logger.debug("Exception raised: %s" % e)
+    finally:
+        return logger
+
+
+def set_logger(name="FakeNetListener", config=None, logging_level=logging.INFO):
+    """
+    Set default logger for listeners
+
+    :param name: Unique string to identify the Listener
+    :param config: listener_config object updated with containing remotelogger_config
+    :param logging_level: logging verbosity
+    :return: logger with either splunk or syslog handlers
+    """
+    logger = logging.getLogger(name)
+    logger.setLevel(logging_level)
+    logger.propagate = False
+    stream_handler = logging.StreamHandler()
+    stream_handler.setLevel(logging_level)
+    stream_formatter = logging.Formatter('%(asctime)s [%(name)18s] %(message)s', datefmt='%m/%d/%y %I:%M:%S %p')
+    stream_handler.setFormatter(stream_formatter)
+    logger.addHandler(stream_handler)
+
+    if config['enableremotelogger']:
+        try:
+            if config['logger_type'] == 'splunk':
+                add_splunk_logger(
+                    config['logger_host'],
+                    config['splunk_hectoken'],
+                    logger,
+                    config['logger_port'],
+                    config['splunk_cert_verify'],
+                    source=name
+                )
+            elif config['logger_type'] == 'syslog':
+                add_remote_logger(
+                    config['logger_host'],
+                    logger,
+                    int(config['logger_port']),
+                    config['logger_protocol']
+                )
+        except Exception as e:
+            logger.warning("Failed to add %s log handler for %s" % (config['logger_type'], name))
+            logger.debug("Exception raised: %s") % e
+            logger.debug("Config: \n%s") % config
+
+    return logger
+

--- a/fakenet/listeners/RawListener.py
+++ b/fakenet/listeners/RawListener.py
@@ -1,4 +1,5 @@
 import logging
+import ListenerBase
 
 import os
 import sys
@@ -19,15 +20,10 @@ class RawListener():
     def __init__(self, 
             config, 
             name='RawListener',
-            logger=None,
-            logging_level=logging.INFO, 
+            logging_level=logging.INFO,
             ):
 
-        self.logger = logger or logging.getLogger(name)
-
-        #self.logger.name = name
-        self.logger.setLevel(logging_level)
-
+        self.logger = ListenerBase.set_logger("%s:%s" % (self.__module__, name), config, logging_level)
         self.config = config
         self.name = name
         self.local_ip = '0.0.0.0'
@@ -35,6 +31,8 @@ class RawListener():
         self.name = 'Raw'
         self.port = self.config.get('port', 1337)
 
+        self.logger.info('Starting %s %s Listener (SSL:%s) on %s:%s'
+                         % (self.name, self.config['protocol'], self.config.get('usessl'), self.local_ip, self.port))
         self.logger.debug('Initialized with config:')
         for key, value in config.iteritems():
             self.logger.debug('  %10s: %s', key, value)
@@ -81,8 +79,6 @@ class RawListener():
         
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.daemon = True
-        self.logger.info('Starting %s %s Listener (SSL:%s) on %s:%s'
-            % (self.name, self.config['protocol'], self.config.get('usessl'), self.local_ip, self.port))
         self.server_thread.start()
 
     def stop(self):


### PR DESCRIPTION
I use fakenet-ng as a sinkhole and one of our primary needs is to be able to monitor traffic hitting the sinkhole and capture useful details such as HTTP headers, requested resources, credentials etc.

P.S I tried to minimize drastic changes to the upstream code.

**1.  Implemented remote logging capabilities.**  
- Feature can be easily enabled/disabled/configured via the Fakenet ini.  Examples have been added.
- TCP/UDP Syslog support
- Splunk HTTP Event Collector (HEC) support added.  For Splunk HEC, I use splunk_http_handler.  In case you are using Splunk HEC listener with SSL, the [splunk_http_handler module in python repo](https://pypi.python.org/pypi/splunk_http_handler/1.0.1) will not work.  Instead use [my updates to the same library](https://github.com/vavarachen/splunk_http_handler).
- When possible, [Common Information Model](http://docs.splunk.com/Documentation/CIM/4.9.1/User/Overview) compliant field names are used when constructing messages for remote logging
- Events logged to Splunk are filtered using logging.filter to only send json formatted events.
- Each listener is configured with its own dedicated remote logger

**2. HTTPListener/BITSListener** 
Logging implemented by overloading BaseHTTPRequestHander.log_message.

Sample get request logged in json format
![image](https://user-images.githubusercontent.com/10197687/34647830-87393ffc-f353-11e7-8651-9458a7ad69f0.png)


**3. FTPListener**
Logging implemented by overloading FTPHandler.log_cmd function (Log commands and responses in a standardized format.).

We can reconstruct the entire transaction (`index=hec source="listeners.FTPListener*"  | transaction src, src_port`)  using user,src and src_port.  For example, the transaction below show the user login, download a file, download a file and then quit. 

```
{
	"dest_port": 2121,
	"ftp_cmd": "AUTH",
	"ftp_cmd_args": "SSL",
	"ftp_respcode": 234,
	"listener": "listeners.FTPListener",
	"log_level": "INFO",
	"src": "127.0.0.1",
	"src_port": 37256,
	"user": ""
} {
	"dest_port": 2121,
	"ftp_cmd": "USER",
	"ftp_cmd_args": "JAMES",
	"ftp_respcode": 331,
	"listener": "listeners.FTPListener",
	"log_level": "INFO",
	"src": "127.0.0.1",
	"src_port": 37256,
	"user": "JAMES"
} {
	"dest_port": 2121,
	"ftp_cmd": "PASS",
	"ftp_cmd_args": "BOND",
	"ftp_respcode": 230,
	"listener": "listeners.FTPListener",
	"log_level": "INFO",
	"src": "127.0.0.1",
	"src_port": 37256,
	"user": "JAMES"
} {
	"dest_port": 2121,
	"ftp_cmd": "SYST",
	"ftp_cmd_args": "",
	"ftp_respcode": 215,
	"listener": "listeners.FTPListener",
	"log_level": "INFO",
	"src": "127.0.0.1",
	"src_port": 37256,
	"user": "JAMES"
} {
	"dest_port": 2121,
	"ftp_cmd": "TYPE",
	"ftp_cmd_args": "I",
	"ftp_respcode": 200,
	"listener": "listeners.FTPListener",
	"log_level": "INFO",
	"src": "127.0.0.1",
	"src_port": 37256,
	"user": "JAMES"
} {
	"dest_port": 2121,
	"ftp_cmd": "EPRT",
	"ftp_cmd_args": "[127.0.0.1]:47321",
	"ftp_respcode": 200,
	"listener": "listeners.FTPListener",
	"log_level": "INFO",
	"src": "127.0.0.1",
	"src_port": 37256,
	"user": "JAMES"
} {
	"dest_port": 2121,
	"ftp_cmd": "RETR",
	"ftp_cmd_args": "/git/flare-fakenet-ng/fakenet/defaultFiles/fake.file.txt",
	"ftp_respcode": 125,
	"listener": "listeners.FTPListener",
	"log_level": "INFO",
	"src": "127.0.0.1",
	"src_port": 37256,
	"user": "JAMES"
}
```
**3. ProxyListener/RawListener**
Logging implemented by extending Threated[TCP|UDP]RequestHandler classes.  In the case of RawListener, log message preserves the hex output.

![image](https://user-images.githubusercontent.com/10197687/34647901-1285cd7c-f355-11e7-9f2e-5c5e93854246.png)

**4. SMTPListener/TFTPListener**
Logging implemented by extending handle() method of Threaded[TCP|UDP]RequestHander classes.
```
{
	"dest_port": 2525,
	"domain": ["EHLO microsoft.com%0D%0A"],
	"listener": "listeners.SMTPListener",
	"log_level": "INFO",
	"smtp_cmd": "EHLO",
	"src": "127.0.0.1",
	"src_port": 43170
} {
	"dest_port": 2525,
	"listener": "listeners.SMTPListener",
	"log_level": "INFO",
	"smtp_cmd": "MAIL",
	"src": "127.0.0.1",
	"src_port": 43170,
	"src_user": ["MAIL FROM: bill.gates@microsoft.com%0D%0A"]
} {
	"dest_port": 2525,
	"listener": "listeners.SMTPListener",
	"log_level": "INFO",
	"recipient": ["RCPT TO: a@skype.com%0D%0A"],
	"smtp_cmd": "RCPT",
	"src": "127.0.0.1",
	"src_port": 43170
} {
	"dest_port": 2525,
	"listener": "listeners.SMTPListener",
	"log_level": "INFO",
	"recipient": ["RCPT TO: b@skype.com%0D%0A"],
	"smtp_cmd": "RCPT",
	"src": "127.0.0.1",
	"src_port": 43170
} {
	"dest_port": 2525,
	"listener": "listeners.SMTPListener",
	"log_level": "INFO",
	"message": "%0D%0A%0D%0AType AUTH LOGIN. The server responds with an encrypted prompt for your user name.%0D%0A%0D%0AEnter your user name encrypted in base 64. You can use one of several tools that are available to encode your user name.%0D%0A%0D%0AThe server responds with an encrypted base 64 prompt for your password. Enter your password encrypted in base 64.%0D%0A%0D%0AType MAIL FROM:<sender@domain.com>%2C and then press ENTER. If the sender is not permitted to send mail%2C the SMTP server returns an error.%0D%0A%0D%0AType RCPT TO:<recipient@remotedomai%0D%0A%0D%0A.%0D%0A",
	"smtp_cmd": "DATA",
	"src": "127.0.0.1",
	"src_port": 43170
} {
	"dest_port": 2525,
	"listener": "listeners.SMTPListener",
	"log_level": "INFO",
	"message": ["QUIT%0D%0A"],
	"smtp_cmd": "QUIT",
	"src": "127.0.0.1",
	"src_port": 43170
}
```
 **5. ListenerBase**
Remote logger functions are implemented in the ListenerBase, which has been imported into all listeners.  I had to add the 'remotelogger_config' to 'listener_config' in order to avoid drastic changes.

**To Do**
- Improve user input handling before blindly handing off to loggers.  
- Write logging.filter to drop json formatted events in stream handler output
- Bring FakeNet daemon operational logs into the fold for health monitoring

** Known Issues**
- Use of `ListenerBase.set_logger("%s:%s" % (self.__module__, name), config, logging_level)` blows up the process name and makes the file/screen log output all screwy.  I wish I could set the logger.name per handler :-/
- A lot of the redundant code could be avoided by developing a higher level Listener class which could incorporate many of the logging related details.  I did not want to made drastic changes.