### PR TITLE
This exception syntax does not work for python 3

### DIFF
--- a/fakenet/fakenet.py
+++ b/fakenet/fakenet.py
@@ -220,7 +220,7 @@ class Fakenet(object):
 
                 try:
                     listener_provider_instance.start()
-                except Exception, e:
+                except Exception as e:
                     self.logger.error('Error starting %s listener on port %s:', listener_config['listener'], listener_config['port'])
                     self.logger.error(" %s" % e)
 


### PR DESCRIPTION
This exception syntax does not work for python 3.  You can no longer use ','s, you must us 'as.'