### PR TITLE
Add Windows 10 NCSI response

### DIFF
--- a/fakenet/defaultFiles/connecttest.txt
+++ b/fakenet/defaultFiles/connecttest.txt
@@ -1,0 +1,1 @@
+Microsoft Connect Test


### PR DESCRIPTION
On Windows 10, the Network Connectivity Status Indicator is based on a request made to the following URL: http://www.msftconnecttest.com/connecttest.txt

This PR adds a valid response so that Windows 10 systems are considered connected to the Internet when using fakenet-ng.