### PR TITLE
Set most listeners to hidden by default. Updated proxy docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -642,7 +642,7 @@ UDP port blacklist as follows:
 Proxy Listener
 --------------
 
-The latest release of FakeNet-NG implements a new proxy listener which is capable of
+FakeNet-NG implements a new proxy listener which is capable of
 dynamically detecting communicating protocol (including SSL traffic) and redirecting
 the connecting to an appropriate listener.
 

--- a/fakenet/configs/default.ini
+++ b/fakenet/configs/default.ini
@@ -161,6 +161,10 @@ BlackListPortsUDP: 67, 68, 137, 138, 443, 1900, 5355
 #                      * {src_port} - source port
 #                      * {dst_addr} - destination address
 #                      * {dst_port} - destination port
+# * Hidden           - Do not allow traffic to be directed to this listener
+#                      without going through the proxy which will determine the
+#                      protocol based on the packet contents. The proxy must be
+#                      enabled for the listener to receive traffic.
 #
 # Listener entry which does not specify a specific listener service
 # will still redirect all packets to the local machine on the specified port and
@@ -231,7 +235,7 @@ Protocol:    TCP
 Listener:    RawListener
 UseSSL:      No
 Timeout:     10
-Hidden:      False
+Hidden:      True
 
 [RawUDPListener]
 Enabled:     True
@@ -240,7 +244,7 @@ Protocol:    UDP
 Listener:    RawListener
 UseSSL:      No
 Timeout:     10
-Hidden:      False
+Hidden:      True
 
 [FilteredListener]
 Enabled:     False
@@ -262,7 +266,7 @@ ResponseA:   192.0.2.123
 ResponseMX:  mail.evil2.com
 ResponseTXT: FAKENET
 NXDomains:   0
-Hidden:      False
+Hidden:      True
 
 [HTTPListener80]
 Enabled:     True
@@ -275,7 +279,7 @@ Timeout:     10
 #ProcessBlackList: dmclient.exe, OneDrive.exe, svchost.exe, backgroundTaskHost.exe, GoogleUpdate.exe, chrome.exe
 DumpHTTPPosts: Yes
 DumpHTTPPostsFilePrefix: http
-Hidden:      False
+Hidden:      True
 # To read about customizing HTTP responses, see docs/CustomResponse.md
 # Custom:    sample_http_custom.ini
 
@@ -288,7 +292,7 @@ UseSSL:      Yes
 Webroot:     defaultFiles/
 DumpHTTPPosts: Yes
 DumpHTTPPostsFilePrefix: http
-Hidden:      False
+Hidden:      True
 
 [SMTPListener]
 Enabled:     True
@@ -325,7 +329,7 @@ UseSSL:      No
 Banner:      !generic
 ServerName:  !gethostname
 Timeout:     30
-Hidden:      False
+Hidden:      True
 
 [TFTPListener]
 Enabled:     True
@@ -333,7 +337,7 @@ Port:        69
 Protocol:    UDP
 Listener:    TFTPListener
 TFTPRoot:    defaultFiles/
-Hidden:      False
+Hidden:      True
 TFTPFilePrefix:  tftp
 
 [POPServer]


### PR DESCRIPTION
POP, SMTP, FTP listeners remain unhidden due to undesirable behavior in multihost mode.