### PR TITLE
Add CRL to allow cert revocation check with TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ install dependencies as follows:
 
 2) In Windows, install Python dependencies by running the following commands with admin privileges:
 
-        python -m pip install pydivert dnslib dpkt pyopenssl pyftpdlib netifaces jinja2
+        python -m pip install pydivert dnslib dpkt pyopenssl==24.2.1 pyftpdlib netifaces jinja2
 
     *NOTE*: pydivert will also download and install WinDivert library and
     driver in the `%PYTHONHOME%\DLLs` directory. FakeNet-NG bundles those
@@ -131,7 +131,7 @@ install dependencies as follows:
         # This will get the required version of cffi packages for cryptography
         python -m pip install --upgrade cryptography
 
-        python -m pip install netfilterqueue dnslib dpkt pyopenssl pyftpdlib netifaces jinja2
+        python -m pip install netfilterqueue dnslib dpkt pyopenssl==24.2.1 pyftpdlib netifaces jinja2
 
    Optionally, you can install the following module used for testing:
 

--- a/fakenet/listeners/HTTPListener.py
+++ b/fakenet/listeners/HTTPListener.py
@@ -217,7 +217,8 @@ class HTTPListener(object):
                 'networkmode': self.config.get('networkmode', None),
                 'static_ca': self.config.get('static_ca', 'No'),
                 'ca_cert': self.config.get('ca_cert'),
-                'ca_key': self.config.get('ca_key')
+                'ca_key': self.config.get('ca_key'),
+                'webroot': self.config.get('webroot')
             }
             self.sslwrapper = SSLWrapper(config)
             self.server.sslwrapper = self.sslwrapper

--- a/fakenet/listeners/HTTPListener.py
+++ b/fakenet/listeners/HTTPListener.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 
 import logging
 from configparser import ConfigParser
@@ -213,12 +213,12 @@ class HTTPListener(object):
         if self.config.get('usessl') == 'Yes':
             self.logger.debug("HTTP Listener starting with SSL")
             config = {
-                'cert_dir': self.config.get('cert_dir', 'configs/temp_certs'),
+                'cert_dir': self.config.get('cert_dir', os.path.join('configs', 'temp_certs')),
                 'networkmode': self.config.get('networkmode', None),
                 'static_ca': self.config.get('static_ca', 'No'),
                 'ca_cert': self.config.get('ca_cert'),
                 'ca_key': self.config.get('ca_key'),
-                'webroot': self.config.get('webroot')
+                'webroot': self.webroot_path
             }
             self.sslwrapper = SSLWrapper(config)
             self.server.sslwrapper = self.sslwrapper

--- a/fakenet/listeners/ProxyListener.py
+++ b/fakenet/listeners/ProxyListener.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 
 import socket
 import socketserver
@@ -54,7 +54,7 @@ class ProxyListener(object):
 
                 self.logger.debug('Starting TCP ...')                
                 config = {
-                    'cert_dir': self.config.get('cert_dir', 'configs/temp_certs'),
+                    'cert_dir': self.config.get('cert_dir', os.path.join('configs', 'temp_certs')),
                     'networkmode': self.config.get('networkmode', None),
                     'static_ca': self.config.get('static_ca', 'No'),
                     'ca_cert': self.config.get('ca_cert'),

--- a/fakenet/listeners/ssl_utils/__init__.py
+++ b/fakenet/listeners/ssl_utils/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 
 import time
 import os

--- a/fakenet/listeners/ssl_utils/__init__.py
+++ b/fakenet/listeners/ssl_utils/__init__.py
@@ -24,6 +24,7 @@ class SSLWrapper(object):
         self.config = config
         self.ca_cert = None
         self.ca_key = None
+        self.ca_crl = None
         self.ca_cn = self.CN
 
         cert_dir = self.abs_config_path(self.config.get('cert_dir', None))
@@ -39,11 +40,11 @@ class SSLWrapper(object):
             self.ca_key = self.abs_config_path(self.config.get('ca_key', None))
             self.ca_cn = self._load_cert(self.ca_cert).get_subject().CN
         else:
-            self.ca_cert, self.ca_key = self.create_cert(self.CN)
+            self.ca_cert, self.ca_key, self.ca_crl = self.create_cert(self.CN)
         if ( not self.config.get('networkmode', None) == 'multihost' and
              not self.config.get('static_ca').lower() == 'yes'):
             self.logger.debug('adding root cert: %s', self.ca_cert)
-            self._add_root_ca(self.ca_cert)
+            self._add_root_ca(self.ca_cert, self.ca_crl)
 
     def wrap_socket(self, s):
         try:
@@ -74,17 +75,23 @@ class SSLWrapper(object):
 
         cert_file = os.path.join(cert_dir, "%s.crt" % (cn))
         key_file = os.path.join(cert_dir, "%s.key" % (cn))
-        if os.path.exists(cert_file) and os.path.exists(key_file):
-            return cert_file, key_file
+        crl_file = os.path.join(cert_dir, "ca.crl")
+        if os.path.exists(cert_file) and os.path.exists(key_file) and os.path.exists(crl_file):
+            webroot = self.config.get("webroot")
+            if webroot and os.path.exists(webroot):
+                web_crl_path = os.path.join(webroot, "ca.crl")
+                if not os.path.exists(web_crl_path):
+                    shutil.copyfile(crl_file, web_crl_path)
+            return cert_file, key_file, crl_file
 
         if ca_cert is not None and ca_key is not None:
             ca_cert_data = self._load_cert(ca_cert)
             if ca_cert_data is None:
-                return None, None
+                return None, None, None
 
             ca_key_data = self._load_private_key(ca_key)
             if ca_key_data is None:
-                return None, None
+                return None, None, None
 
         # generate crypto keys:
         key = crypto.PKey()
@@ -106,17 +113,45 @@ class SSLWrapper(object):
         cert.gmtime_adj_notAfter(na)
         cert.set_pubkey(key)
         if f_selfsign:
+            # root CA cert
             extensions = [
                 crypto.X509Extension(b'basicConstraints', True, b'CA:TRUE'),
+                crypto.X509Extension(b"keyUsage", True, b"keyCertSign, cRLSign"),
+                crypto.X509Extension(b"crlDistributionPoints", False, b"URI:http://fakenet.mandiant.com/ca.crl")
             ]
             cert.set_issuer(cert.get_subject())
             cert.add_extensions(extensions)
             cert.sign(key, "sha256")
+
+            # empty CRL for this CA
+            crl = crypto.CRL()
+            now = time.strftime("%Y%m%d%H%M%SZ", time.gmtime())
+            next_update = time.strftime("%Y%m%d%H%M%SZ", time.gmtime(time.time() + (30 * 24 * 60 * 60))) # 30 days
+            crl.set_lastUpdate(now.encode('ascii'))
+            crl.set_nextUpdate(next_update.encode('ascii'))
+            crl.set_version(1)
+            crl.sign(cert, key, digest=b"sha256")
+            crl_der = crl.export(cert, key, crypto.FILETYPE_ASN1, digest=b"sha256")
+
+            # write CRL to disk to import into cert store and also serve over HTTP when necessary
+            try:
+                with open(crl_file, "wb") as f:
+                    f.write(crl_der)
+                webroot = self.config.get("webroot")
+                if webroot and os.path.exists(webroot):
+                    with open(os.path.join(webroot, "ca.crl"), "wb") as f:
+                        f.write(crl_der)
+            except IOError:
+                traceback.print_exc()
+                return None, None, None
+
         else:
+            # leaf cert for a requested domain
             alt_name = b'DNS:' + cn.encode()
             extensions = [
                 crypto.X509Extension(b'basicConstraints', False, b'CA:FALSE'),
-                crypto.X509Extension(b'subjectAltName', False, alt_name)
+                crypto.X509Extension(b'subjectAltName', False, alt_name),
+                crypto.X509Extension(b"crlDistributionPoints", False, b"URI:http://fakenet.mandiant.com/ca.crl")
             ]
             cert.set_issuer(ca_cert_data.get_subject())
             cert.add_extensions(extensions)
@@ -133,8 +168,8 @@ class SSLWrapper(object):
                 )
         except IOError:
             traceback.print_exc()
-            return None, None
-        return cert_file, key_file
+            return None, None, None
+        return cert_file, key_file, crl_file
 
     def sni_callback(self, sslsock, servername, sslctx):
         if servername is None:
@@ -142,7 +177,7 @@ class SSLWrapper(object):
         newctx = ssl.SSLContext(ssl.PROTOCOL_TLS)
         newctx.options |= ssl.OP_NO_TLSv1
         newctx.options |= ssl.OP_NO_TLSv1_1
-        cert_file, key_file = self.create_cert(servername, self.ca_cert, self.ca_key)
+        cert_file, key_file, _ = self.create_cert(servername, self.ca_cert, self.ca_key)
         if cert_file is None or key_file is None:
             return
 
@@ -175,6 +210,7 @@ class SSLWrapper(object):
         rc = True
         if sys.platform.startswith('win'):
             try:
+                self.logger.debug(f"Running cmd: {argv}")
                 subprocess.check_call(argv, shell=True, stdout=None)
                 rc = True
             except subprocess.CalledProcessError:
@@ -182,12 +218,20 @@ class SSLWrapper(object):
                 rc = False
         return rc
 
-    def _add_root_ca(self, ca_cert_file):
+    def _add_root_ca(self, ca_cert_file, ca_crl_file):
         argv = ['certutil', '-addstore', 'Root', ca_cert_file]
+        installed_cert = self._run_process(argv)
+        if not installed_cert:
+            return False
+        argv = ['certutil', '-addstore', 'CA', ca_crl_file]
         return self._run_process(argv)
 
     def _remove_root_ca(self, cn):
         argv = ['certutil', '-delstore', 'Root', cn]
+        removed = self._run_process(argv)
+        if not removed:
+            return False
+        argv = ['certutil', '-delstore', 'CA', cn]
         return self._run_process(argv)
 
     def __del__(self):
@@ -195,6 +239,10 @@ class SSLWrapper(object):
                 not self.config.get('static_ca').lower() == 'yes'): 
             self._remove_root_ca(self.ca_cn)
         shutil.rmtree(self.abs_config_path(self.config.get('cert_dir', None)), ignore_errors=True)
+        if self.config.get("webroot"):
+            crl = os.path.join(self.config.get("webroot"), "ca.crl")
+            if os.path.exists(crl):
+                os.remove(crl)
         return
 
     def abs_config_path(self, path):

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Google LLC
+# Copyright 2026 Google LLC
 
 import os
 import platform
@@ -14,6 +14,8 @@ requirements = [
     "netifaces",
     "pyftpdlib",
     "cryptography",
+    # Pin pyopenssl to 24.2.1 because newer versions removed CRL functionality.
+    # TODO: Migrate ssl_utils/__init__.py to cryptography to unpin.
     "pyopenssl==24.2.1",
     "jinja2",
 ]

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     "netifaces",
     "pyftpdlib",
     "cryptography",
-    "pyopenssl",
+    "pyopenssl==24.2.1",
     "jinja2",
 ]
 


### PR DESCRIPTION
Resolves #210 

curl (usually) uses schannel, Windows' built-in TLS package, which usually checks that the certificate is still valid. It can do this using either a CRL installed in the Windows cert store (see: `certmgr.msc`) or can download a CRL from a URL specified in a trusted certificate. This PR takes both approaches: it generates an empty CRL and signs it with the root CA we generate, and both installs it in the Windows store and tries to put it in the FakeNet webroot directory to serve it over HTTP if that is necessary. Some TLS libraries may prefer one or the other approach, so this should handle both.